### PR TITLE
Add grade writing tool

### DIFF
--- a/src/components/dashboards/StudentDashboard.tsx
+++ b/src/components/dashboards/StudentDashboard.tsx
@@ -207,7 +207,11 @@ export function StudentDashboard({ userId }: StudentDashboardProps) {
         )}
 
         {showGradeWriting && (
-          <GradeWritingPanel onBackClick={() => handleBack("grade")} />
+          <GradeWritingPanel
+            assignmentCode={selectedAssignmentCode}
+            userId={userId}
+            onBackClick={() => handleBack("grade")}
+          />
         )}
 
         {selectedFeedback && (

--- a/src/components/dashboards/StudentDashboard.tsx
+++ b/src/components/dashboards/StudentDashboard.tsx
@@ -7,6 +7,7 @@ import { HelpOptionsMenu } from "./student/HelpOptionsMenu";
 import { StuckOptionsPanel } from "./student/StuckOptionsPanel";
 import { TargetedFeedbackPanel } from "./student/TargetedFeedbackPanel";
 import { GeneralFeedbackPanel } from "./student/GeneralFeedbackPanel";
+import { GradeWritingPanel } from "./student/GradeWritingPanel";
 import { FeedbackResultPanel } from "./student/FeedbackResultPanel";
 import { AssignmentDetailsPanel } from "./student/AssignmentDetailsPanel";
 import { AssignmentSelectionPanel } from "./student/AssignmentSelectionPanel";
@@ -28,6 +29,7 @@ export function StudentDashboard({ userId }: StudentDashboardProps) {
   const [showStuckOptions, setShowStuckOptions] = useState(false);
   const [showGeneralFeedbackOptions, setShowGeneralFeedbackOptions] =
     useState(false);
+  const [showGradeWriting, setShowGradeWriting] = useState(false);
   const [selectedFeedback, setSelectedFeedback] = useState<string | null>(null);
   const [feedbackSource, setFeedbackSource] = useState<string | null>(null);
   const [enteredValidClassCode, setEnteredValidClassCode] = useState(false);
@@ -84,6 +86,9 @@ export function StudentDashboard({ userId }: StudentDashboardProps) {
     } else if (source === "help") {
       setShowHelpOptions(false);
       setShowAssignmentDetails(true);
+    } else if (source === "grade") {
+      setShowGradeWriting(false);
+      setShowHelpOptions(true);
     } else {
       // For feedback page
       if (feedbackSource === "stuck") {
@@ -171,6 +176,10 @@ export function StudentDashboard({ userId }: StudentDashboardProps) {
               setShowHelpOptions(false);
               setShowGeneralFeedbackOptions(true);
             }}
+            onGradeWritingClick={() => {
+              setShowHelpOptions(false);
+              setShowGradeWriting(true);
+            }}
             onBackClick={() => handleBack("help")}
           />
         )}
@@ -195,6 +204,10 @@ export function StudentDashboard({ userId }: StudentDashboardProps) {
 
         {showGeneralFeedbackOptions && (
           <GeneralFeedbackPanel onBackClick={() => handleBack("general")} />
+        )}
+
+        {showGradeWriting && (
+          <GradeWritingPanel onBackClick={() => handleBack("grade")} />
         )}
 
         {selectedFeedback && (

--- a/src/components/dashboards/student/GradeWritingPanel.tsx
+++ b/src/components/dashboards/student/GradeWritingPanel.tsx
@@ -1,14 +1,181 @@
 import PageFrame from "./PageFrame";
+import { fetchDocumentContent } from "../../../utils/extractText";
+import { Prompts } from "@/src/prompts";
+import { useState } from "react";
 
+import { Button } from "../../ui/button";
+import {
+  chatHistoryRepository,
+  ChatHistoryRepository,
+} from "@/src/domains/chat_history/repository";
+import { supabase } from "@/lib/supabaseClient";
+import { chatHistoryService } from "@/src/domains/chat_history/service";
+
+import { assignmentRepository } from "@/src/domains/assignments/repository";
+import { assignmentService } from "@/src/domains/assignments/service";
+import { Assignment } from "@/src/domains/assignments/model";
 type GradeWritingPanelProps = {
+  userId: string;
   onBackClick: () => void;
+  assignmentCode: string | null;
 };
 
-export function GradeWritingPanel({ onBackClick }: GradeWritingPanelProps) {
+import appConfig from "@/app.config";
+async function callOpenAI(userId: string, tool: string, prompt: any) {
+  let responseFeedback = "";
+
+  try {
+    const response = await fetch("https://api.openai.com/v1/chat/completions", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${appConfig.openaiApiKey}`,
+      },
+      body: JSON.stringify({
+        model: "gpt-4",
+        messages: [{ role: "user", content: prompt }],
+        store: true,
+      }),
+    });
+
+    const dataJson = await response.json();
+    responseFeedback = dataJson.choices[0]?.message?.content || {
+      score: "",
+      rationale: "",
+    };
+
+    let feedback = JSON.parse(responseFeedback);
+
+    const feedbackDictionary = {
+      name: tool,
+      feedback: feedback,
+    };
+
+    const newFeedbackService = chatHistoryService(
+      chatHistoryRepository(supabase)
+    );
+    const { data, error } = await newFeedbackService.createChatHistory(
+      userId,
+      tool,
+      JSON.stringify(feedbackDictionary)
+    );
+    return feedback;
+  } catch (error) {
+    console.error("Error:", error);
+    return { score: "", rationale: "" };
+  }
+}
+
+export function GradeWritingPanel({
+  assignmentCode,
+  userId,
+  onBackClick,
+}: GradeWritingPanelProps) {
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [assignment, setAssignment] = useState<Assignment | null>(null);
+  const [feedback, setFeedback] = useState<{
+    current_draft: string[];
+    previous_draft: string[];
+  }>({
+    current_draft: [],
+    previous_draft: [],
+  });
+
+  useEffect(() => {
+    async function fetchAssignmentDetails() {
+      if (assignmentCode) {
+        try {
+          setLoading(true);
+          const service = assignmentService(assignmentRepository(supabase));
+          const assignmentData = await service.getAssignmentDetails(
+            assignmentCode
+          );
+
+          if (assignmentData) {
+            setAssignment(assignmentData);
+          } else {
+            setError("Could not find assignment details");
+          }
+        } catch (err) {
+          setError("Failed to load assignment details");
+        } finally {
+          setLoading(false);
+        }
+      }
+    }
+
+    fetchAssignmentDetails();
+  }, [assignmentCode]);
+
+  async function handleGradeWriting() {
+    const documentText = await fetchDocumentContent();
+    const instructions = assignment?.instruction ? assignment?.instruction : "";
+    const rubric = assignment?.rubric ? assignment?.rubric : "";
+    const prompt = Prompts.GRADE_WRITING_PROMPT.format({
+      currentDraft: documentText,
+      instructions: instructions,
+      rubric: rubric,
+    });
+
+    const gradeResult = await callOpenAI(userId, "grade", prompt);
+    const score = gradeResult.score;
+    const rationale = gradeResult.rationale;
+
+    setFeedback((prev) => ({
+      ...prev,
+      current_draft: [documentText, score, rationale],
+    }));
+  }
+
+  async function handleRegradeWriting() {
+    const documentText = await fetchDocumentContent();
+    const instructions = assignment?.instruction ? assignment?.instruction : "";
+    const rubric = assignment?.rubric ? assignment?.rubric : "";
+    const prompt = Prompts.REGRADE_WRITING_PROMPT.format({
+      currentDraft: documentText,
+      previousDraft: feedback.current_draft[0],
+      previousFeedback: feedback.current_draft[2],
+      instructions: instructions,
+      rubric: rubric,
+    });
+
+    const gradeResult = await callOpenAI(userId, "grade", prompt);
+    const score = gradeResult.score;
+    const rationale = gradeResult.rationale;
+
+    setFeedback((prev) => ({
+      current_draft: [documentText, score, rationale],
+      previous_draft: prev.current_draft,
+    }));
+  }
+
   return (
     <PageFrame onBackClick={onBackClick} title="What do you want to work on?">
-      <div className="p-4 bg-white rounded-lg border border-lime-100 shadow-sm">
-        <p className="text-center text-gray-500">Chat interface goes here</p>
+      <Button
+        onClick={
+          feedback.current_draft.length === 0
+            ? handleGradeWriting
+            : handleRegradeWriting
+        }
+      >
+        {feedback.current_draft.length === 0
+          ? "Grade Writing"
+          : "Re-grade Writing"}
+      </Button>
+
+      <div className="pt-7">
+        {feedback.current_draft.length === 0 ? (
+          <p>Click "Grade Writing" to get a score for your writing.</p>
+        ) : (
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+            <h3 className="font-bold mb-1 text-lg">
+              Predicted Score: {feedback.current_draft[1]}
+            </h3>
+
+            <p className="text-base">{feedback.current_draft[2]}</p>
+          </div>
+        )}
       </div>
     </PageFrame>
   );

--- a/src/components/dashboards/student/GradeWritingPanel.tsx
+++ b/src/components/dashboards/student/GradeWritingPanel.tsx
@@ -1,0 +1,15 @@
+import PageFrame from "./PageFrame";
+
+type GradeWritingPanelProps = {
+  onBackClick: () => void;
+};
+
+export function GradeWritingPanel({ onBackClick }: GradeWritingPanelProps) {
+  return (
+    <PageFrame onBackClick={onBackClick} title="What do you want to work on?">
+      <div className="p-4 bg-white rounded-lg border border-lime-100 shadow-sm">
+        <p className="text-center text-gray-500">Chat interface goes here</p>
+      </div>
+    </PageFrame>
+  );
+}

--- a/src/components/dashboards/student/GradeWritingPanel.tsx
+++ b/src/components/dashboards/student/GradeWritingPanel.tsx
@@ -1,8 +1,7 @@
+import React, { useEffect, useState } from "react";
 import PageFrame from "./PageFrame";
 import { fetchDocumentContent } from "../../../utils/extractText";
 import { Prompts } from "@/src/prompts";
-import { useState } from "react";
-
 import { Button } from "../../ui/button";
 import {
   chatHistoryRepository,
@@ -10,18 +9,27 @@ import {
 } from "@/src/domains/chat_history/repository";
 import { supabase } from "@/lib/supabaseClient";
 import { chatHistoryService } from "@/src/domains/chat_history/service";
-
 import { assignmentRepository } from "@/src/domains/assignments/repository";
 import { assignmentService } from "@/src/domains/assignments/service";
 import { Assignment } from "@/src/domains/assignments/model";
-type GradeWritingPanelProps = {
+import appConfig from "@/app.config";
+
+interface Feedback {
+  current_draft: string[];
+  previous_draft: string[];
+}
+
+interface GradeWritingPanelProps {
   userId: string;
   onBackClick: () => void;
   assignmentCode: string | null;
-};
+}
 
-import appConfig from "@/app.config";
-async function callOpenAI(userId: string, tool: string, prompt: any) {
+async function callOpenAI(
+  userId: string,
+  tool: string,
+  prompt: string
+): Promise<{ score: string; rationale: string }> {
   let responseFeedback = "";
 
   try {
@@ -71,13 +79,10 @@ export function GradeWritingPanel({
   userId,
   onBackClick,
 }: GradeWritingPanelProps) {
-  const [loading, setLoading] = useState(true);
+  const [loading, setLoading] = useState<boolean>(true);
   const [error, setError] = useState<string | null>(null);
   const [assignment, setAssignment] = useState<Assignment | null>(null);
-  const [feedback, setFeedback] = useState<{
-    current_draft: string[];
-    previous_draft: string[];
-  }>({
+  const [feedback, setFeedback] = useState<Feedback>({
     current_draft: [],
     previous_draft: [],
   });

--- a/src/components/dashboards/student/GradeWritingPanel.tsx
+++ b/src/components/dashboards/student/GradeWritingPanel.tsx
@@ -153,6 +153,7 @@ export function GradeWritingPanel({
   return (
     <PageFrame onBackClick={onBackClick} title="What do you want to work on?">
       <Button
+        className="w-full bg-lime-600 hover:bg-lime-700 text-white"
         onClick={
           feedback.current_draft.length === 0
             ? handleGradeWriting
@@ -166,9 +167,18 @@ export function GradeWritingPanel({
 
       <div className="pt-7">
         {feedback.current_draft.length === 0 ? (
-          <p>Click "Grade Writing" to get a score for your writing.</p>
+          <p className="text-base">
+            Get an AI-generated score and feedback based on the assignment
+            rubric from your teacher.
+          </p>
         ) : (
           <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+            <div className="text-gray-500 italic text-sm mt-1">
+              <p>
+                Disclaimer: This is an AI-generated response. It may contain
+                mistakes. Please check the feedback carefully.
+              </p>
+            </div>
             <h3 className="font-bold mb-1 text-lg">
               Predicted Score: {feedback.current_draft[1]}
             </h3>

--- a/src/components/dashboards/student/HelpOptionsMenu.tsx
+++ b/src/components/dashboards/student/HelpOptionsMenu.tsx
@@ -7,6 +7,7 @@ type HelpOptionsMenuProps = {
   onStuckClick: () => void;
   onTargetedFeedbackClick: () => void;
   onGeneralFeedbackClick: () => void;
+  onGradeWritingClick: () => void;
   onBackClick: () => void;
 };
 
@@ -14,6 +15,7 @@ export function HelpOptionsMenu({
   onStuckClick,
   onTargetedFeedbackClick,
   onGeneralFeedbackClick,
+  onGradeWritingClick,
   onBackClick,
 }: HelpOptionsMenuProps) {
   return (
@@ -43,6 +45,12 @@ export function HelpOptionsMenu({
           buttonText="I Need Targeted Feedback"
           description="I want feedback on a specific part of my writing."
           onClick={onTargetedFeedbackClick}
+        />
+
+        <MainMenuOption
+          buttonText="Grade My Writing"
+          description="I want AI to provide a grade with the assignment rubric."
+          onClick={onGradeWritingClick}
         />
       </div>
     </div>

--- a/src/prompts/grade/gradeWritingPrompt.ts
+++ b/src/prompts/grade/gradeWritingPrompt.ts
@@ -1,0 +1,34 @@
+import { PromptTemplate } from "../basePrompt";
+
+export const GRADE_WRITING_PROMPT = new PromptTemplate(
+  "grade_writing",
+  "0.0.1",
+  `You are a writing assistant that helps secondary students develop a piece of writing.  The student has indicated that they would like to see what score their current draft might get based on the instructions and rubric.  Score the student's writing based on the directions and rubric.  Provide feedback to the students about their current draft and how they might improve.  You will respond with a valid JSON object that contains their score and rationale explaining the score.  The feedback should contain information about what they did well and suggestions for further improvements.  You will NOT explain your reasons.
+
+  ## Assignment Instructions
+  {instructions}
+
+  ## Assignment Rubric
+  {rubric}
+
+  ## Student's Writing
+  {currentDraft}
+
+  ## Feedback characteristics
+  - Concise, easy-to-read, 6th-grade reading level
+  - Write concise feedback up to 600 characters
+  - Explain 1-2 strengths of the student's writing.
+  - Explain 1-2 areas of improvement for the student's writing.
+  - If the rubric is an analytic rubric, your feedback should cover each category.
+  - If the rubric is a holistic rubric, your feedback should target the most appropriate grade band.
+
+  ## JSON Format
+  - Create a JSON object with each feedback point.
+  {
+    "score": "3",
+    "rationale": "Your essay is well-organized and presents clear arguments, which is why it falls in category 3. You provide good points about technology's impact on education, jobs, and communication. However, some arguments could be further developed with more specific examples. The writing is mostly clear, though there are some areas where sentence variety and transitions could be improved. Your conclusion effectively summarizes the discussion, but restating the main ideas in a new way would strengthen it. Keep up the good work!"
+  }
+
+  Feedback:
+  `
+);

--- a/src/prompts/grade/regradeWritingPrompt.ts
+++ b/src/prompts/grade/regradeWritingPrompt.ts
@@ -1,7 +1,7 @@
 import { PromptTemplate } from "../basePrompt";
 
 export const REGRADE_WRITING_PROMPT = new PromptTemplate(
-  "grade_writing",
+  "regrade_writing",
   "0.0.1",
   `You are a writing assistant that helps secondary students develop a piece of writing.  The student has revised their writing and would like to see how their revisions impact their score.
   

--- a/src/prompts/grade/regradeWritingPrompt.ts
+++ b/src/prompts/grade/regradeWritingPrompt.ts
@@ -1,0 +1,45 @@
+import { PromptTemplate } from "../basePrompt";
+
+export const REGRADE_WRITING_PROMPT = new PromptTemplate(
+  "grade_writing",
+  "0.0.1",
+  `You are a writing assistant that helps secondary students develop a piece of writing.  The student has revised their writing and would like to see how their revisions impact their score.
+  
+  Score the student's writing and provide feedback to them based on the directions and rubric.  Consider how their essay has changed based on the old feedback and draft.
+  
+  You will respond with a valid JSON object that contains their score and rationale explaining the score.  The feedback should contain information about what they did well and suggestions for further improvements.  You will NOT explain your reasons.
+
+  ## Assignment Instructions
+  {instructions}
+
+  ## Assignment Rubric
+  {rubric}
+
+  ## Previous Draft
+  {previousDraft}
+
+  ## Previous Feedback
+  {previousFeedback}
+
+  ## Student's Writing
+  {currentDraft}
+
+  ## Feedback characteristics
+  - Concise, easy-to-read, 6th-grade reading level
+  - Write concise feedback up to 600 characters
+  - Explain 1-2 strengths of the student's writing.
+  - Explain 1-2 areas of improvement for the student's writing.
+  - If the rubric is an analytic rubric, your feedback should cover each category.
+  - If the rubric is a holistic rubric, your feedback should target the most appropriate grade band.
+  - Explain how changes in the writing have impacted the score going up or down
+
+  ## JSON Format
+  - Create a JSON object with each feedback point.
+  {
+    "score": "3",
+    "rationale": "You essay continues to be well-organized with clear, convincing arguments.  You did a good job revising the essay to develop your ideas more with examples and clearer language.  These revisions help improve your score to a 4.  While you have improved the transitions, there are still some places in the writing that could benefit from more logical connections."
+  }
+
+  Feedback:
+  `
+);

--- a/src/prompts/index.ts
+++ b/src/prompts/index.ts
@@ -8,6 +8,8 @@ import { CONTINUE_WRITING_PROMPT } from "./stuck/continueWritingPrompt";
 import { PREWRITING_PROMPT } from "./stuck/prewritingPrompt";
 import { GETTING_STARTED_PROMPT } from "./stuck/getStartedPrompt";
 import { FINISH_WRITING_PROMPT } from "./stuck/finishWritingPrompt";
+import { GRADE_WRITING_PROMPT } from "./grade/gradeWritingPrompt";
+import { REGRADE_WRITING_PROMPT } from "./grade/regradeWritingPrompt";
 
 export const Prompts = {
   // Stuck Support
@@ -22,4 +24,7 @@ export const Prompts = {
   PARAGRAPH_STRUCTURE_PROMPT,
   GRAMMAR,
   TRANSITIONS_PROMPT,
+  // Grade Writing
+  GRADE_WRITING_PROMPT,
+  REGRADE_WRITING_PROMPT,
 };


### PR DESCRIPTION
This PR adds a grade prediction tool to the available resources for students.  It replaces the "general feedback" chat feature.  This tool evaluates the student's writing based on the instructions and rubric.  It provides students with a tentative score and a rationale for the score.

As students re-write their essay, they can request a re-grade.  This follow-up evaluation incorporates the previous draft and feedback when creating new feedback based on the current draft.

Changes
* [x] Add a panel for the graded writing tool
* [x] Add a prompt to grade the current draft
* [x] Add a prompt to regrade the current draft (with context about the previous draft)